### PR TITLE
Updated checkbox component

### DIFF
--- a/src/components/auth/CheckBox.js
+++ b/src/components/auth/CheckBox.js
@@ -7,13 +7,13 @@ class CheckBox extends Component {
     return (
       <label htmlFor="check-box-recover" className="relative cursor-pointer ">
         <input
-          className=" mr-2 h-2 w-2 appearance-none rounded-md border border-gray-400 p-2 checked:bg-checkbox-green "
+          className="peer mr-2 h-2 w-2 appearance-none rounded-md border border-gray-400 p-2 checked:bg-checkbox-green "
           type="checkbox"
           id="check-box-recover"
           name="recover"
         />
         <img
-          className="check-arrow invisible absolute inset-0 h-4 w-4"
+          className="invisible absolute inset-0 h-4 w-4 peer-checked:visible"
           src={doneArrow}
           alt="done arrow"
         />

--- a/src/index.css
+++ b/src/index.css
@@ -1,7 +1,3 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-
-#check-box-recover:checked ~ .check-arrow {
-  @apply visible;
-}


### PR DESCRIPTION
- Use the peer tailwindcss class instead of custom combined selectors
  (the simplest the better case)
